### PR TITLE
Added a sound control in the game options menu

### DIFF
--- a/client/audio.c
+++ b/client/audio.c
@@ -171,6 +171,9 @@ bool audio_select_plugin(const char *const name)
 
   selected_plugin = i;
   log_verbose("Plugin '%s' is now selected", plugins[selected_plugin].name);
+  
+  plugins[selected_plugin].set_volume(gui_options.sound_effects_volume / 100.0);
+  
   return TRUE;
 }
 

--- a/client/audio_sdl.c
+++ b/client/audio_sdl.c
@@ -102,7 +102,7 @@ static bool sdl_audio_play(const char *const tag, const char *const fullpath,
     }
     log_verbose("Playing file \"%s\" on music channel", fullpath);
     /* in case we did a sdl_audio_stop() recently; add volume controls later */
-    Mix_VolumeMusic(MIX_MAX_VOLUME);
+    Mix_VolumeMusic(sdl_audio_volume * MIX_MAX_VOLUME);
 
   } else {
 

--- a/client/options.c
+++ b/client/options.c
@@ -145,7 +145,8 @@ struct client_options gui_options = {
   .sound_enable_effects = TRUE,
   .sound_enable_menu_music = TRUE,
   .sound_enable_game_music = TRUE,
-
+  .sound_effects_volume = 100,
+  
 /* This option is currently set by the client - not by the user. */
   .update_city_text_in_refresh_tile = TRUE,
 
@@ -1850,6 +1851,7 @@ static void font_changed_callback(struct option *poption);
 static void mapimg_changed_callback(struct option *poption);
 static void game_music_enable_callback(struct option *poption);
 static void menu_music_enable_callback(struct option *poption);
+static void sound_volume_callback(struct option *poption);
 
 static struct client_option client_options[] = {
   GEN_STR_OPTION(default_user_name,
@@ -2317,6 +2319,13 @@ static struct client_option client_options[] = {
                      "assuming there's suitable "
                      "sound plugin and musicset with menu music tracks."),
                   COC_SOUND, GUI_STUB, TRUE, menu_music_enable_callback),
+  GEN_INT_OPTION(sound_effects_volume,
+  		 N_("Sound volume"),
+  		 N_("Volume scale from 0-100"),
+  		 COC_SOUND, GUI_STUB, 100,
+  		 0, 100,
+  		 sound_volume_callback),
+  		 
   GEN_BOOL_OPTION(autoaccept_soundset_suggestion,
                   N_("Autoaccept soundset suggestions"),
                   N_("If this option is enabled, any soundset suggested by "
@@ -6332,6 +6341,14 @@ static void menu_music_enable_callback(struct option *poption)
       stop_menu_music();
     }
   }
+}
+
+/**********************************
+ Callback for changing music volume
+ **********************************/
+static void sound_volume_callback( struct option *poption)
+{
+	audio_set_volume(gui_options.sound_effects_volume / 100.0);
 }
 
 /************************************************************************//**

--- a/client/options.h
+++ b/client/options.h
@@ -165,6 +165,7 @@ struct client_options
   bool sound_enable_effects;
   bool sound_enable_menu_music;
   bool sound_enable_game_music;
+  int sound_effects_volume;
 
   bool draw_city_outlines;
   bool draw_city_output;


### PR DESCRIPTION
Reworked the issue #885685 in the original dev. Modified audio files to add a sound control in the game options menu,