### PR TITLE
Changed the settings dialog title to be more consistent with the settings button

### DIFF
--- a/client/gui-gtk-3.22/menu.c
+++ b/client/gui-gtk-3.22/menu.c
@@ -566,7 +566,7 @@ static void save_chat_logs_callback(GtkMenuItem *item, gpointer data)
 ****************************************************************************/
 static void local_options_callback(GtkMenuItem *item, gpointer data)
 {
-  option_dialog_popup(_("Set local options"), client_optset);
+  option_dialog_popup(_("Set client options"), client_optset);
 }
 
 /************************************************************************//**

--- a/client/gui-gtk-3.22/pages.c
+++ b/client/gui-gtk-3.22/pages.c
@@ -137,7 +137,7 @@ static void connect_network_game_callback(GtkWidget *w, gpointer data)
 **************************************************************************/
 static void open_settings(void)
 {
-  option_dialog_popup(_("Set local options"), client_optset);
+  option_dialog_popup(_("Set client options"), client_optset);
 }
 
 /**********************************************************************//**


### PR DESCRIPTION
I Changed the settings dialog title to be more consistent with the settings button by modifying the files specific to gtk-3.22. 