### PR TITLE
Changed Clinet Settings pop up window title to "Client Settings"

### DIFF
--- a/client/gui-gtk-3.22/menu.c
+++ b/client/gui-gtk-3.22/menu.c
@@ -566,7 +566,7 @@ static void save_chat_logs_callback(GtkMenuItem *item, gpointer data)
 ****************************************************************************/
 static void local_options_callback(GtkMenuItem *item, gpointer data)
 {
-  option_dialog_popup(_("Set local options"), client_optset);
+  option_dialog_popup(_("Client Settings"), client_optset);
 }
 
 /************************************************************************//**

--- a/client/gui-gtk-3.22/pages.c
+++ b/client/gui-gtk-3.22/pages.c
@@ -137,7 +137,7 @@ static void connect_network_game_callback(GtkWidget *w, gpointer data)
 **************************************************************************/
 static void open_settings(void)
 {
-  option_dialog_popup(_("Set local options"), client_optset);
+  option_dialog_popup(_("Client Settings"), client_optset);
 }
 
 /**********************************************************************//**


### PR DESCRIPTION
To make the pop up window title to be less ambiguous for the user, the title was changed from "Set local option" to "Client Settings"