### PR TITLE
issue: fix client dialog title

### DIFF
--- a/client/gui-gtk-3.22/pages.c
+++ b/client/gui-gtk-3.22/pages.c
@@ -137,7 +137,7 @@ static void connect_network_game_callback(GtkWidget *w, gpointer data)
 **************************************************************************/
 static void open_settings(void)
 {
-  option_dialog_popup(_("Set local options"), client_optset);
+  option_dialog_popup(_("Client Settings"), client_optset);
 }
 
 /**********************************************************************//**


### PR DESCRIPTION
Change the dialog title from "Set local options" to "Client Settings"